### PR TITLE
Change to setup hook

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,1 +1,1 @@
-Hooks.on('init', () => game.settings.set('core', 'notesDisplayToggle', true));
+Hooks.on('setup', () => game.settings.set('core', 'notesDisplayToggle', true));


### PR DESCRIPTION
The notesDisplayToggle setting is not registered yet during the init hook (at least in 0.6.6). Changing this to fire during the setup hook resolves the issue.